### PR TITLE
Release/2.1.0

### DIFF
--- a/.github/workflows/WP_6_3.yaml
+++ b/.github/workflows/WP_6_3.yaml
@@ -1,4 +1,4 @@
-name: WP6.5 [PHP7.4-8.2] Tests
+name: WP6.5 [PHP7.4-8.3] Tests
 
 on:
   push:

--- a/.github/workflows/WP_6_3.yaml
+++ b/.github/workflows/WP_6_3.yaml
@@ -1,0 +1,64 @@
+name: WP6.5 [PHP7.4-8.2] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor 
+          && rm -rf composer.lock 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock 
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.5.* --dev --no-update
+          && composer require roots/wordpress:6.5.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.5.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on Latest Version - WP6.5
+        env:
+          environment_github: true
+        run: composer all

--- a/.github/workflows/WP_6_4.yaml
+++ b/.github/workflows/WP_6_4.yaml
@@ -1,4 +1,4 @@
-name: WP6.4 [PHP7.4-8.2] Tests
+name: WP6.4 [PHP7.4-8.3] Tests
 
 on:
   push:

--- a/.github/workflows/WP_6_4.yaml
+++ b/.github/workflows/WP_6_4.yaml
@@ -1,4 +1,4 @@
-name: WP6.1 [PHP7.4-8.2] Tests
+name: WP6.4 [PHP7.4-8.2] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -53,15 +53,12 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.1.0 --dev --no-update
-          && composer require roots/wordpress:6.1.* --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.4.* --dev --no-update
+          && composer require roots/wordpress:6.4.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.4.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.1
+      - name: Run Tests on Latest Version - WP6.4
         env:
           environment_github: true
         run: composer all
-
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_ADMIN_PAGES }}
- 

--- a/.github/workflows/WP_6_5.yaml
+++ b/.github/workflows/WP_6_5.yaml
@@ -1,4 +1,4 @@
-name: WP6.3 [PHP7.4-8.2] Tests
+name: WP6.3 [PHP7.4-8.3] Tests
 
 on:
   push:

--- a/.github/workflows/WP_6_5.yaml
+++ b/.github/workflows/WP_6_5.yaml
@@ -1,4 +1,4 @@
-name: WP6.0 [PHP7.4-8.1] Tests
+name: WP6.3 [PHP7.4-8.2] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.4', '8.0', '8.1']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -53,16 +53,12 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:6.0.0 --dev --no-update
-          && composer require roots/wordpress:6.0.0 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:6.0.0 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.3.* --dev --no-update
+          && composer require roots/wordpress:6.3.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.3.* --dev --no-update
           && composer update --no-cache
 
-      - name: Run Tests on Latest Version - WP6.0
+      - name: Run Tests on Latest Version - WP6.3
         env:
           environment_github: true
         run: composer all
-
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_ADMIN_PAGES }}
- 

--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -1,4 +1,4 @@
-name: WP5.9 [PHP7.4-8.1] Tests
+name: WP6.6 [PHP7.4-8.2] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.4', '8.0', '8.1']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3.', '8.4']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -53,12 +53,16 @@ jobs:
         run: >
           rm -rf composer.lock 
           && composer clearcache
-          && composer require php-stubs/wordpress-stubs:5.9.0 --dev --no-update
-          && composer require roots/wordpress:5.9.4 --dev --no-update
-          && composer require wp-phpunit/wp-phpunit:5.9.4 --dev --no-update
+          && composer require php-stubs/wordpress-stubs:6.3.* --dev --no-update
+          && composer require roots/wordpress:6.3.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.3.* --dev --no-update
           && composer update --no-cache
-      
-      - name: Run Tests on WP5.9
+
+      - name: Run Tests on Latest Version - WP6.3
         env:
           environment_github: true
         run: composer all
+
+      - name: Codecov
+        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_ADMIN_PAGES }}
+ 

--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -1,4 +1,4 @@
-name: WP6.6 [PHP7.4-8.2] Tests
+name: WP6.6 [PHP7.4-8.3] Tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3.', '8.4']
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3.']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 
 A module for the Perique Plugin Framework, for rendering and processing Admin Menu Pages with WordPress
 
-[![Latest Stable Version](http://poser.pugx.org/pinkcrab/perique-admin-menu/v)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
-[![Total Downloads](http://poser.pugx.org/pinkcrab/perique-admin-menu/downloads)](https://packagist.org/packages/pinkcrab/perique-admin-menu) 
-[![License](http://poser.pugx.org/pinkcrab/perique-admin-menu/license)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
-[![PHP Version Require](http://poser.pugx.org/pinkcrab/perique-admin-menu/require/php)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
+[![Latest Stable Version](https://poser.pugx.org/pinkcrab/perique-admin-menu/v)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
+[![Total Downloads](https://poser.pugx.org/pinkcrab/perique-admin-menu/downloads)](https://packagist.org/packages/pinkcrab/perique-admin-menu) 
+[![License](https://poser.pugx.org/pinkcrab/perique-admin-menu/license)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
+[![PHP Version Require](https://poser.pugx.org/pinkcrab/perique-admin-menu/require/php)](https://packagist.org/packages/pinkcrab/perique-admin-menu)
 ![GitHub contributors](https://img.shields.io/github/contributors/Pink-Crab/Perique_Admin_Menu?label=Contributors)
 ![GitHub issues](https://img.shields.io/github/issues-raw/Pink-Crab/Perique_Admin_Menu)
 
-[![WP5.9 [PHP7.4-8.1] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_5_9.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_5_9.yaml)[![WP6.0 [PHP7.4-8.1] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_0.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_0.yaml)[![WP6.1 [PHP7.4-8.1] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_1.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_1.yaml)[![WP6.2 [PHP7.4-8.2] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_2.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_2.yaml)
+[![W6.2 [PHP7.4-8.2] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_2.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_2.yaml)
+[![WP6.3 [PHP7.4-8.2] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_3.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_3.yaml)
+[![WP6.4 [PHP7.4-8.3] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_4.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_4.yaml)
+[![WP6.5 [PHP7.4-8.3] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_5.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_5.yaml)
+[![WP6.6 [PHP7.4-8.4] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml)
 
 [![codecov](https://codecov.io/gh/Pink-Crab/Perique_Admin_Menu/branch/master/graph/badge.svg)](https://codecov.io/gh/Pink-Crab/Perique_Admin_Menu)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/Perique_Admin_Menu/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/Perique_Admin_Menu/?branch=master)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ All code must be supplied with matching tests and must pass PHPUNIT, PHPStan and
 See composer.json for details on the test and linting commands. `composer all` is the most important.
 
 # Change Log 
+* 2.1.0 - Added support for Perique 2.1.x and updated some dev dependencies.
 * 2.0.0 - Migrated to Perique 2.0.0
 * 1.0.1 - Separated out the docs and added `page_hook()` method to page models and sets the hook after registration.
 * 1.0.0 - Finalised API for Perique 1.4.*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A module for the Perique Plugin Framework, for rendering and processing Admin Me
 [![WP6.3 [PHP7.4-8.2] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_3.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_3.yaml)
 [![WP6.4 [PHP7.4-8.3] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_4.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_4.yaml)
 [![WP6.5 [PHP7.4-8.3] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_5.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_5.yaml)
-[![WP6.6 [PHP7.4-8.4] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml)
+[![WP6.6 [PHP7.4-8.3] Tests](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml/badge.svg)](https://github.com/Pink-Crab/Perique_Admin_Menu/actions/workflows/WP_6_6.yaml)
 
 [![codecov](https://codecov.io/gh/Pink-Crab/Perique_Admin_Menu/branch/master/graph/badge.svg)](https://codecov.io/gh/Pink-Crab/Perique_Admin_Menu)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Pink-Crab/Perique_Admin_Menu/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Pink-Crab/Perique_Admin_Menu/?branch=master)

--- a/composer.json
+++ b/composer.json
@@ -26,24 +26,28 @@
         "phpunit/phpunit": "^7.0 || ^8.0",
         "phpstan/phpstan": "1.*",
         "szepeviktor/phpstan-wordpress": "<=1.1.7",
-        "php-stubs/wordpress-stubs": "6.1.* || 5.9.*",
-        "roots/wordpress": "6.1.*",
-        "wp-phpunit/wp-phpunit": "6.1.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "<=1.0.0",
-        "wp-coding-standards/wpcs": "<=2.3.0",
         "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0",
         "symfony/var-dumper": "<=6.2.7",
+        "php-stubs/wordpress-stubs": "6.6.*",
+        "roots/wordpress": "6.6.*",
+        "wp-phpunit/wp-phpunit": "6.6.*",
+        "wp-cli/i18n-command": "*",
+        "squizlabs/php_codesniffer": "3.*",
+        "dealerdirect/phpcodesniffer-composer-installer": "*",
+        "roave/security-advisories": "dev-latest",
+        "wp-coding-standards/wpcs": "^3",
         "gin0115/wpunit-helpers": "1.1.*",
         "vlucas/phpdotenv": "<=5.5.0"
     },
     "require": {
         "php": ">=7.4.0",
-        "pinkcrab/perique-framework-core": "2.0.*"
+        "pinkcrab/perique-framework-core": "2.1.*"
     },
     "scripts": {
         "test": "phpunit --coverage-clover clover.xml --testdox",
         "coverage": "phpunit --coverage-html coverage-report --testdox",
         "analyse": "vendor/bin/phpstan analyse src -l8",
+        "format": "./vendor/bin/phpcbf src -v",
         "sniff": "./vendor/bin/phpcs src/ -v",
         "all": "composer test && composer analyse && composer sniff"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,6 +14,7 @@
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass" />
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
 	</rule>
 
 	<!-- Add in some extra rules from other standards. -->

--- a/src/Exception/Page_Exception.php
+++ b/src/Exception/Page_Exception.php
@@ -82,5 +82,4 @@ class Page_Exception extends Exception {
 			202
 		);
 	}
-
 }

--- a/src/Group/Abstract_Group.php
+++ b/src/Group/Abstract_Group.php
@@ -85,7 +85,7 @@ abstract class Abstract_Group {
 	 */
 	public function get_group_title(): string {
 		if ( $this->group_title === null ) {
-			throw Group_Exception::group_title_undefined( $this );
+			throw Group_Exception::group_title_undefined( $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 		return $this->group_title;
 	}
@@ -115,7 +115,7 @@ abstract class Abstract_Group {
 	 */
 	public function get_primary_page(): string {
 		if ( $this->primary_page === null ) {
-			throw Group_Exception::primary_page_undefined( $this );
+			throw Group_Exception::primary_page_undefined( $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 		return $this->primary_page;
 	}
@@ -132,7 +132,7 @@ abstract class Abstract_Group {
 	/**
 	 * Set holds the groups menu position.
 	 *
-	 * @return int
+	 * @return integer
 	 */
 	public function get_position(): int {
 		return $this->position;
@@ -142,7 +142,7 @@ abstract class Abstract_Group {
 	 * Callback for enqueuing scripts and styles at a group level.
 	 *
 	 * @param Abstract_Group $group
-	 * @param Page $page
+	 * @param Page           $page
 	 * @return void
 	 * @codeCoverageIgnore This can't be tested as it does nothing and is extended only
 	 */
@@ -154,7 +154,7 @@ abstract class Abstract_Group {
 	 * Callback for triggering pre load actions for the groups page (at group level)
 	 *
 	 * @param Abstract_Group $group
-	 * @param Page $page
+	 * @param Page           $page
 	 * @return void
 	 * @codeCoverageIgnore This can't be tested as it does nothing and is extended only
 	 */

--- a/src/Module/Page_Middleware.php
+++ b/src/Module/Page_Middleware.php
@@ -50,49 +50,48 @@ class Page_Middleware implements Registration_Middleware {
 	/**
 	 * Add all valid ajax calls to the dispatcher.
 	 *
-	 * @param object $class
+	 * @param object $class_instance
 	 * @return object
 	 */
-	public function process( object $class ): object {
+	public function process( object $class_instance ): object {
 		// If we have a valid SUB page.
 		if (
-			is_a( $class, Page::class )
+			is_a( $class_instance, Page::class )
 			&& is_admin()
-			&& ! is_null( $class->parent_slug() )
+			&& ! is_null( $class_instance->parent_slug() )
 		) {
 			$this->add_to_loader(
-				function () use ( $class ) : void {
-					$this->dispatcher->register_subpage( $class, $class->parent_slug() );
+				function () use ( $class_instance ): void {
+					$this->dispatcher->register_subpage( $class_instance, $class_instance->parent_slug() );
 				}
 			);
 		}
 
 		// If we have a valid SINGLE/PARENT page.
 		if (
-			is_a( $class, Page::class )
+			is_a( $class_instance, Page::class )
 			&& is_admin()
-			&& is_null( $class->parent_slug() )
+			&& is_null( $class_instance->parent_slug() )
 		) {
 			$this->add_to_loader(
-				function () use ( $class ) : void {
-					$this->dispatcher->register_single_page( $class );
+				function () use ( $class_instance ): void {
+					$this->dispatcher->register_single_page( $class_instance );
 				}
 			);
 		}
 
 		// If we have a valid group.
 		if (
-			is_a( $class, Abstract_Group::class )
+			is_a( $class_instance, Abstract_Group::class )
 			&& is_admin()
 		) {
-
 			$this->add_to_loader(
-				function () use ( $class ): void {
-					$this->dispatcher->register_group( $class );
+				function () use ( $class_instance ): void {
+					$this->dispatcher->register_group( $class_instance );
 				}
 			);
 		}
-		return $class;
+		return $class_instance;
 	}
 
 	/**

--- a/src/Page/Menu_Page.php
+++ b/src/Page/Menu_Page.php
@@ -123,7 +123,7 @@ abstract class Menu_Page implements Page {
 	 */
 	public function slug(): string {
 		if ( $this->page_slug === '' ) {
-			throw Page_Exception::undefined_property( 'page_slug', $this );
+			throw Page_Exception::undefined_property( 'page_slug', $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 		return $this->page_slug;
 	}
@@ -133,7 +133,7 @@ abstract class Menu_Page implements Page {
 	 */
 	public function menu_title(): string {
 		if ( $this->menu_title === '' ) {
-			throw Page_Exception::undefined_property( 'menu_title', $this );
+			throw Page_Exception::undefined_property( 'menu_title', $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 		return $this->menu_title;
 	}
@@ -168,18 +168,17 @@ abstract class Menu_Page implements Page {
 	 */
 	public function render_view(): callable {
 		if ( null === $this->view ) {
-			throw Page_Exception::view_not_set( $this );
+			throw Page_Exception::view_not_set( $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 
 		if ( '' === $this->view_template ) {
-			throw Page_Exception::undefined_property( 'view_template', $this );
+			throw Page_Exception::undefined_property( 'view_template', $this ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 
-		return function() {
+		return function () {
 			// @phpstan-ignore-next-line, as we have already checked for null.
 			$this->view->render( $this->view_template, $this->view_data );
 		};
-
 	}
 
 	/**
@@ -224,6 +223,4 @@ abstract class Menu_Page implements Page {
 	final public function page_hook(): ?string {
 		return $this->page_hook;
 	}
-
-
 }

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -70,5 +70,4 @@ interface Page {
 	 * @return ?string
 	 */
 	public function page_hook(): ?string;
-
 }

--- a/src/Registrar/Page_Dispatcher.php
+++ b/src/Registrar/Page_Dispatcher.php
@@ -74,7 +74,6 @@ class Page_Dispatcher {
 				$this->register_subpage( $page, $this->get_primary_page( $group )->slug(), $group );
 			}
 			$this->set_primary_page_details( $group );
-
 		} catch ( \Throwable $th ) {
 			$this->admin_exception_notice( $group, $th );
 		}
@@ -83,19 +82,19 @@ class Page_Dispatcher {
 	/**
 	 * Handles the display of errors thrown registering admin menu pages in wp_admin.
 	 *
-	 * @param Abstract_Group|Page $object
-	 * @param \Throwable $exception
+	 * @param Abstract_Group|Page $object_instance
+	 * @param \Throwable          $exception
 	 * @return void
 	 */
-	public function admin_exception_notice( $object, Throwable $exception ): void {
+	public function admin_exception_notice( $object_instance, Throwable $exception ): void {
 		add_action(
 			'admin_notices',
-			function() use ( $object, $exception ) {
+			function () use ( $object_instance, $exception ) {
 				$class   = 'notice notice-error';
 				$message = sprintf(
 					'%s <i>%s</i> generated errors while being registered. This might result in admin pages being missing or broken. <br><b>%s(%s: %s)</b>',
-					get_class( $object ) === Page::class ? 'Page' : 'Menu Group',
-					get_class( $object ),
+					get_class( $object_instance ) === Page::class ? 'Page' : 'Menu Group',
+					get_class( $object_instance ),
 					$exception->getMessage(),
 					$exception->getFile(),
 					$exception->getLine()
@@ -136,11 +135,13 @@ class Page_Dispatcher {
 	 * @return \PinkCrab\Perique_Admin_Menu\Page\Page
 	 */
 	protected function get_primary_page( Abstract_Group $group ): Page {
-		/** @var Page */
+		/**
+ * @var Page
+*/
 		$page = $this->di_container->create( $group->get_primary_page() );
 
 		if ( ! is_object( $page ) || ! is_a( $page, Page::class ) ) {
-			throw Page_Exception::invalid_page_type( $page );
+			throw Page_Exception::invalid_page_type( $page ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 		}
 
 		// Register view if requied.
@@ -161,16 +162,16 @@ class Page_Dispatcher {
 	 */
 	protected function get_pages( Abstract_Group $group ): array {
 		return array_map(
-			function( string $page ): Page {
+			function ( string $page ): Page {
 				$constructed_page = $this->di_container->create( $page );
 				if ( ! is_object( $constructed_page ) || ! is_a( $constructed_page, Page::class ) ) {
-					throw Page_Exception::invalid_page_type( $constructed_page );
+					throw Page_Exception::invalid_page_type( $constructed_page ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped, escaped in exception.
 				}
 				return $constructed_page;
 			},
 			array_filter(
 				$group->get_pages(),
-				function( string $page ) use ( $group ) {
+				function ( string $page ) use ( $group ) {
 					return $page !== $group->get_primary_page();
 				}
 			)
@@ -199,7 +200,7 @@ class Page_Dispatcher {
 			$primary->slug(),
 			\array_column( $submenu[ $primary->slug() ], 2 ),
 			true
-		) ?: 0;
+		) ?: 0; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		$submenu[ $primary->slug() ][ $primary_page_key ][0] = $primary->menu_title();
 	}
@@ -208,8 +209,8 @@ class Page_Dispatcher {
 	/**
 	 * Registers a subpage.
 	 *
-	 * @param \PinkCrab\Perique_Admin_Menu\Page\Page $page
-	 * @param string $parent_slug
+	 * @param \PinkCrab\Perique_Admin_Menu\Page\Page                 $page
+	 * @param string                                                 $parent_slug
 	 * @param \PinkCrab\Perique_Admin_Menu\Group\Abstract_Group|null $group
 	 * @return void
 	 */
@@ -249,6 +250,4 @@ class Page_Dispatcher {
 			$this->admin_exception_notice( $page, $th );
 		}
 	}
-
-
 }

--- a/src/Validator/Abstract_Validator.php
+++ b/src/Validator/Abstract_Validator.php
@@ -76,5 +76,5 @@ abstract class Abstract_Validator {
 	 * @param mixed $subject
 	 * @return bool
 	 */
-	abstract public function validate( $subject): bool;
+	abstract public function validate( $subject ): bool;
 }


### PR DESCRIPTION
This pull request includes several updates to the GitHub workflows, dependencies, and codebase. The most important changes are the renaming and updating of workflow files, the addition of new dependencies, and some code refactoring for better clarity and compliance.

### Workflow Updates:
* Renamed and updated `.github/workflows/WP_6_1.yaml` to `.github/workflows/WP_6_3.yaml`, including changes to test PHP 8.3 and WordPress 6.5. [[1]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL1-R1) [[2]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL14-R14) [[3]](diffhunk://#diff-0d08b16dd285be46842db29dd7dd5f0bba68c4366c9f85cf6b611fd3b107cf2aL56-L67)
* Renamed and updated `.github/workflows/WP_5_9.yaml` to `.github/workflows/WP_6_4.yaml`, including changes to test PHP 8.3 and WordPress 6.4. [[1]](diffhunk://#diff-ce57ec975114ddc4b08b136f4db30d1308586d2e699b4ccc92ce6a010610932dL1-R1) [[2]](diffhunk://#diff-ce57ec975114ddc4b08b136f4db30d1308586d2e699b4ccc92ce6a010610932dL14-R14) [[3]](diffhunk://#diff-ce57ec975114ddc4b08b136f4db30d1308586d2e699b4ccc92ce6a010610932dL56-R61)
* Added a new workflow file `.github/workflows/WP_6_5.yaml` to test PHP 8.3 and WordPress 6.3.
* Renamed and updated `.github/workflows/WP_6_0.yaml` to `.github/workflows/WP_6_6.yaml`, including changes to test PHP 8.3 and WordPress 6.6. [[1]](diffhunk://#diff-8fe27bfd0cbf5aa0550f2b4c148c09469cf56d2dfded379c3c325af84db9f59eL1-R1) [[2]](diffhunk://#diff-8fe27bfd0cbf5aa0550f2b4c148c09469cf56d2dfded379c3c325af84db9f59eL14-R14) [[3]](diffhunk://#diff-8fe27bfd0cbf5aa0550f2b4c148c09469cf56d2dfded379c3c325af84db9f59eL56-R61)

### Dependency Updates:
* Updated `composer.json` to use the latest versions of dependencies like `php-stubs/wordpress-stubs`, `roots/wordpress`, and `wp-phpunit/wp-phpunit` for WordPress 6.6. Also added new dependencies like `wp-cli/i18n-command` and `squizlabs/php_codesniffer`.

### Code Refactoring:
* Refactored the `Page_Middleware` class to use a more descriptive variable name `$class_instance` instead of `$class`.
* Added PHP CodeSniffer ignore comments for exception messages in `Abstract_Group` and `Menu_Page` classes to comply with WordPress coding standards. [[1]](diffhunk://#diff-ba4fe2d502f7cb23b18051d3333ac66d13a40d2293b62df051b550e7737d8b88L88-R88) [[2]](diffhunk://#diff-54ad72aa9305b02ec20f18fbfc3bbdfdd451b308e266a1d118ba07e64359710fL126-R126) [[3]](diffhunk://#diff-54ad72aa9305b02ec20f18fbfc3bbdfdd451b308e266a1d118ba07e64359710fL136-R136) [[4]](diffhunk://#diff-54ad72aa9305b02ec20f18fbfc3bbdfdd451b308e266a1d118ba07e64359710fL171-L182)

### Documentation Updates:
* Updated `README.md` to fix badge URLs and add new workflow badges for the updated workflows. Also added a new entry to the change log for version 2.1.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157)

### Minor Fixes:
* Added a new exclusion rule in `phpcs.xml` for `PSR12.Files.FileHeader.IncorrectOrder`.
* Removed unused code and fixed minor formatting issues in several files. [[1]](diffhunk://#diff-b608a37b7df8ca90da9b17a06ab4b820bf3fbdcd95d29234d8265b601f3454b6L85) [[2]](diffhunk://#diff-54ad72aa9305b02ec20f18fbfc3bbdfdd451b308e266a1d118ba07e64359710fL227-L228) [[3]](diffhunk://#diff-10d9d101549444c0cc9fa55f980e249ac4f44036e25c83fe3e828015ce883889L73) [[4]](diffhunk://#diff-f33b55bdaf252bd4f26c0cec05d7584ad8034389d9d79f3ac7357aee952dedd7L77)